### PR TITLE
Fixed #57 Set background in gray color on xDAI column when ETH network selected (vice versa previously working)

### DIFF
--- a/src/components/AirdropRewards.tsx
+++ b/src/components/AirdropRewards.tsx
@@ -186,7 +186,7 @@ function Rewards() {
 					</SpaceBetween>
 				</Row>
 			</RewardsSection>
-			<RewardsSection>
+			<RewardsSection disabled={!isDN(network)}>
 				<SpaceBetween>
 					<label className={isDN(network) ? 'green' : 'disabled'}>
 						XDAI
@@ -291,6 +291,7 @@ const RewardsSection = styled.section`
 	padding: 16px;
 	border-radius: 24px;
 	border: 1px solid #dde3e3;
+	background: ${props => (props.disabled ? '#F4F6F6' : 'white')};
 	label {
 		background: #eefcfb;
 		border-radius: 16px;

--- a/src/components/Rewards.tsx
+++ b/src/components/Rewards.tsx
@@ -192,7 +192,7 @@ function Rewards() {
 					</SpaceBetween>
 				</Row>
 			</RewardsSection>
-			<RewardsSection>
+			<RewardsSection disabled={!isDN(network)}>
 				<SpaceBetween>
 					<label className={isDN(network) ? 'green' : 'disabled'}>
 						xDAI


### PR DESCRIPTION
Fixed #57

![image](https://user-images.githubusercontent.com/7695193/125491510-024529dd-b991-49cc-8a1d-4a062e097b20.png)

![image](https://user-images.githubusercontent.com/7695193/125491548-abd86092-6a18-4fc6-aa0c-fcb88cd61d7f.png)
