### PR TITLE
Fix #104 Make Navbar usable on mobile portrait

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -65,11 +65,6 @@ const Container = styled.div`
 			margin: 0 15px;
 		}
 	}
-	@media only screen and (max-width: 444px) {
-		img {
-			width: 190px;
-		}
-	}
 `
 
 export default Navbar


### PR DESCRIPTION
Fixed #104 - Navbar icon is small for large screen, it should be small for small screens too

From

<img width="323" alt="image" src="https://user-images.githubusercontent.com/7695193/126268778-5465f5bd-4b7d-493c-909a-7712b4800315.png">

To

<img width="327" alt="image" src="https://user-images.githubusercontent.com/7695193/126268886-eff9bc7a-7962-47d8-8fa5-5f7ae7c46496.png">
