### PR TITLE
Fix #144 Get more NODE button with no links on NODEstream

### DIFF
--- a/src/components/APRDetails.tsx
+++ b/src/components/APRDetails.tsx
@@ -14,7 +14,7 @@ import { convertEthHelper } from '../lib/numbers'
 
 interface APRDetailsProps {
 	APR: BigNumber | null
-	provideLiquidityLink: string
+	getMoreDNLink: string
 	disabled: boolean
 }
 
@@ -43,7 +43,7 @@ const computeValues = (APR: BigNumber): RoiValues => {
 
 const APRDetails: React.FC<APRDetailsProps> = ({
 	APR,
-	provideLiquidityLink = '',
+	getMoreDNLink = '',
 	disabled = false,
 }) => {
 	if (!APR) return null
@@ -81,10 +81,7 @@ const APRDetails: React.FC<APRDetailsProps> = ({
 					<div className='actions'>
 						<WhiteGreenButtonLink
 							onClick={() => {
-								const win = window.open(
-									provideLiquidityLink,
-									'_blank',
-								)
+								const win = window.open(getMoreDNLink, '_blank')
 								if (win) win.focus()
 							}}
 							disabled={disabled}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -6,7 +6,7 @@ import { Inter700, SpaceBetween, WhiteGreenLink } from './Styles'
 import StakingPoolCard from './StakingPoolCard'
 import config from '../configuration'
 
-const { MAINNET_CONFIG } = config
+const { MAINNET_CONFIG, XDAI_CONFIG } = config
 
 function Dashboard() {
 	return (
@@ -42,6 +42,7 @@ function Dashboard() {
 					logo='/assets/dn-eth-logos.svg'
 					network={config.MAINNET_NETWORK_NUMBER}
 					provideLiquidityLink={`https://app.uniswap.org/#/add/v2/ETH/${MAINNET_CONFIG.TOKEN_ADDRESS}`}
+					getMoreDNLink={`https://app.uniswap.org/#/swap?inputCurrency=ETH&outputCurrency=${MAINNET_CONFIG.TOKEN_ADDRESS}&use=V2`}
 				/>
 				<StakingPoolCard
 					name='NODE/ETH'
@@ -51,6 +52,7 @@ function Dashboard() {
 					logo='/assets/dn-eth-logos.svg'
 					network={config.MAINNET_NETWORK_NUMBER}
 					provideLiquidityLink={`https://app.sushi.com/add/ETH/${MAINNET_CONFIG.TOKEN_ADDRESS}`}
+					getMoreDNLink={`https://app.sushi.com/swap?inputCurrency=ETH&outputCurrency=${MAINNET_CONFIG.TOKEN_ADDRESS}`}
 				/>
 				<StakingPoolCard
 					name='NODE'
@@ -60,6 +62,7 @@ function Dashboard() {
 					logo='/assets/dn-logo.svg'
 					network={config.MAINNET_NETWORK_NUMBER}
 					provideLiquidityLink=''
+					getMoreDNLink={`https://app.uniswap.org/#/swap?inputCurrency=ETH&outputCurrency=${MAINNET_CONFIG.TOKEN_ADDRESS}&use=V2`}
 				/>
 				<StakingPoolCard
 					name='NODE'
@@ -69,6 +72,7 @@ function Dashboard() {
 					logo='/assets/dn-logo.svg'
 					network={config.XDAI_NETWORK_NUMBER}
 					provideLiquidityLink=''
+					getMoreDNLink={`https://app.uniswap.org/#/swap?inputCurrency=ETH&outputCurrency=${MAINNET_CONFIG.TOKEN_ADDRESS}&use=V2`}
 				/>
 			</PoolsContainer>
 		</DashboardSection>

--- a/src/components/PoolCard.tsx
+++ b/src/components/PoolCard.tsx
@@ -127,6 +127,7 @@ const Principal = ({
 		stakedLpTokens,
 		earned,
 		provideLiquidityLink,
+		getMoreDNLink,
 		reserves,
 		poolTotalSupply,
 	} = stakePoolInfo
@@ -170,7 +171,7 @@ const Principal = ({
 					</h2>
 					<APRDetails
 						APR={APR}
-						provideLiquidityLink={provideLiquidityLink}
+						getMoreDNLink={getMoreDNLink}
 						disabled={disabled}
 					/>
 				</SpaceBetween>

--- a/src/components/StakingPoolCard.tsx
+++ b/src/components/StakingPoolCard.tsx
@@ -23,6 +23,7 @@ interface StakingPoolCardProps {
 	platform: string
 	network: number
 	provideLiquidityLink: string
+	getMoreDNLink: string
 }
 
 const StakingPoolCard: React.FC<StakingPoolCardProps> = ({
@@ -33,6 +34,7 @@ const StakingPoolCard: React.FC<StakingPoolCardProps> = ({
 	platform,
 	network,
 	provideLiquidityLink = '',
+	getMoreDNLink = '',
 }) => {
 	const [stakePoolInfo, setStakePoolInfo] = useState<StakePoolInfo>({
 		tokensInPool: 0,
@@ -140,6 +142,7 @@ const StakingPoolCard: React.FC<StakingPoolCardProps> = ({
 			composition={composition}
 			stakePoolInfo={{
 				provideLiquidityLink,
+				getMoreDNLink,
 				...stakePoolInfo,
 				...stakeUserInfo,
 			}}


### PR DESCRIPTION
Fixed #144 

Set the following links for "Get more NODE" button:

- Uniswap: https://app.uniswap.org/#/swap?inputCurrency=ETH&outputCurrency=0xDa007777D86AC6d989cC9f79A73261b3fC5e0DA0
- Sushiswap: https://app.sushi.com/swap?inputCurrency=ETH&outputCurrency=0xDa007777D86AC6d989cC9f79A73261b3fC5e0DA0
- Node Staking: https://app.uniswap.org/#/swap?inputCurrency=ETH&outputCurrency=0xDa007777D86AC6d989cC9f79A73261b3fC5e0DA0
- xNode Staking: https://app.uniswap.org/#/swap?inputCurrency=ETH&outputCurrency=0xDa007777D86AC6d989cC9f79A73261b3fC5e0DA0

xNode Staking goes to Uniswap (mainnet) because in Sushiswap (xDAI) there is no liquidity