### PR TITLE
Fix #166 Activate GET NODE button even if a wallet is not connected

### DIFF
--- a/src/components/PoolCard.tsx
+++ b/src/components/PoolCard.tsx
@@ -195,7 +195,7 @@ const Principal = ({
 					<APRDetails
 						APR={APR}
 						getMoreDNLink={getMoreDNLink}
-						disabled={disabled}
+						disabled={false}
 					/>
 				</SpaceBetween>
 				<SpaceBetween>


### PR DESCRIPTION
Fixed #166 @Pol-Lanski 

![image](https://user-images.githubusercontent.com/7695193/136929314-5f4f9c54-e90c-40a0-9084-a9d7dd6f1d3f.png)
