### PR TITLE
Fix #174 Avoid dapp freezes while signing a request on mobile

### DIFF
--- a/src/lib/stakingPool.ts
+++ b/src/lib/stakingPool.ts
@@ -273,6 +273,7 @@ export async function stakeTokens(
 					amount,
 			  )
 			: await permitTokensXDai(provider, poolAddress, lmAddress)
+	await new Promise(f => setTimeout(f, 500))
 
 	const txResponse: TransactionResponse = await lmContract
 		.connect(signer.connectUnchecked())


### PR DESCRIPTION
Fixed #174 
This is not a fix but a patch. Couldn't find a right solution but the patch fixes the issue.
⚠️ Only merge in case we want mobile first since it adds 0.5s delay while signing in mobile and desktop too.
Try the patch at: https://liquidity-mining-dapp-g01jkqm03-dappnode.vercel.app/